### PR TITLE
Various fixes to support integration into existing react-native apps

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,42 +1,43 @@
 // Components
-export Declan from './src/components';
+export {default as Declan} from './src/components';
 
 // Animators
-export BaseAnimator from './src/animators/BaseAnimator';
-export CompositeAnimator from './src/animators/CompositeAnimator';
-export Fade from './src/animators/Fade';
-export Move from './src/animators/Move';
-export Rotate from './src/animators/Rotate';
-export Scale from './src/animators/Scale';
-export Shake from './src/animators/Shake';
-export Change from './src/animators/Change';
-export Callback from './src/animators/Callback';
-export DebugAction from './src/animators/DebugAction';
+export {default as BaseAnimator} from './src/animators/BaseAnimator';
+export {default as CompositeAnimator} from './src/animators/CompositeAnimator';
+export {default as Fade} from './src/animators/Fade';
+export {default as Move} from './src/animators/Move';
+export {default as Rotate} from './src/animators/Rotate';
+export {default as Scale} from './src/animators/Scale';
+export {default as Shake} from './src/animators/Shake';
+export {default as Change} from './src/animators/Change';
+export {default as Callback} from './src/animators/Callback';
+export {default as DebugAction} from './src/animators/DebugAction';
 
 // Behaviors
-export SwipeGesture from './src/behaviors/SwipeGesture';
+export {default as SwipeGesture} from './src/behaviors/SwipeGesture';
 
 // Higher Order animators
-export Cycle from './src/higher-order-animators/Cycle';
-export Sequence from './src/higher-order-animators/Sequence';
-export Parallel from './src/higher-order-animators/Parallel';
-export Stagger from './src/higher-order-animators/Stagger';
+export {default as Cycle} from './src/higher-order-animators/Cycle';
+export {default as Sequence} from './src/higher-order-animators/Sequence';
+export {default as Parallel} from './src/higher-order-animators/Parallel';
+export {default as Stagger} from './src/higher-order-animators/Stagger';
 
 // Drivers
-export ScrollDriver from './src/drivers/ScrollDriver';
-export PanEventEmitter from './src/drivers/PanEventEmitter';
+export {default as ScrollDriver} from './src/drivers/ScrollDriver';
+export {default as PanEventEmitter} from './src/drivers/PanEventEmitter';
 
 // Triggers
-export BaseTrigger from './src/triggers/BaseTrigger';
-export ManualTrigger from './src/triggers/ManualTrigger';
-export Mounted from './src/triggers/Mounted';
-export WhileScrolling from './src/triggers/WhileScrolling';
-export ScrollPositionAnimation from './src/triggers/ScrollPositionAnimation';
-export SwipingAnimation from './src/triggers/SwipingAnimation';
-export Swiped from './src/triggers/Swiped';
-export State from './src/triggers/State';
-export StateGroup from './src/triggers/StateGroup';
-export WhileTrue from './src/triggers/WhileTrue';
+export {default as BaseTrigger} from './src/triggers/BaseTrigger';
+export {default as ManualTrigger} from './src/triggers/ManualTrigger';
+export {default as Mounted} from './src/triggers/Mounted';
+export {default as WhileScrolling} from './src/triggers/WhileScrolling';
+export {default as ScrollPositionAnimation} from './src/triggers/ScrollPositionAnimation';
+export {default as SwipingAnimation} from './src/triggers/SwipingAnimation';
+export {default as Swiped} from './src/triggers/Swiped';
+export {default as State} from './src/triggers/State';
+export {default as StateGroup} from './src/triggers/StateGroup';
+export {default as WhileTrue} from './src/triggers/WhileTrue';
 
 // Types
 export * from './src/types/index';
+

--- a/package.json
+++ b/package.json
@@ -38,8 +38,6 @@
     "eventemitter3": "^2.0.3",
     "lodash": "^4.17.4",
     "ramda": "^0.25.0",
-    "react": "*",
-    "react-native": "*",
     "uuid": "^3.1.0"
   },
   "devDependencies": {

--- a/src/animators/BaseAnimator.js
+++ b/src/animators/BaseAnimator.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import { Animated, View } from 'react-native';
 import uuid from 'uuid';
 
-import AnimatableView from '../components/AnimatableView';
+import Declan from '../components';
 import { Animator, type AnimatedValue } from '../types';
 
 class BaseAnimator<D, P: any, S> extends Component<D, P, S>
@@ -16,7 +16,7 @@ class BaseAnimator<D, P: any, S> extends Component<D, P, S>
   getAnimationTransformation: $Abstract<() => Object>;
 
   id: string;
-  target: ?AnimatableView;
+  target: ?Declan.View;
   progress: AnimatedValue;
 
   props: P;

--- a/src/triggers/ManualTrigger.js
+++ b/src/triggers/ManualTrigger.js
@@ -2,13 +2,13 @@
 
 import uuid from 'uuid';
 
-import AnimatableView from '../components/AnimatableView';
+import Declan from '../components';
 import BaseTrigger from './BaseTrigger';
 import { Animator, type AnimatedValue } from '../types';
 
 class ManualTrigger extends BaseTrigger implements Animator {
   id: string;
-  target: ?AnimatableView;
+  target: ?Declan.View;
   value: AnimatedValue;
 
   constructor(props) {

--- a/src/triggers/WhileTrue.js
+++ b/src/triggers/WhileTrue.js
@@ -1,28 +1,34 @@
 // @flow
 
-import BaseTrigger from './BaseTrigger';
+import ManualTrigger from './ManualTrigger';
 
 type Props = {
   value: boolean,
 };
 
-class WhileTrue extends BaseTrigger {
+class WhileTrue extends ManualTrigger {
   constructor(props: Props) {
     super(props);
     this.animators = [];
-    this.currentValue = props.value;
+  }
+
+  componentDidMount() {
+    this.updateCurrentValue(this.props.value);
   }
 
   componentWillReceiveProps(newProps: Props) {
-    if (newProps.value === true) {
-      this.animators.forEach(({ ref }) => {
-        ref.start();
-      });
-    } else {
-      this.animators.forEach(({ ref }) => {
-        ref.stop();
-      });
+    this.updateCurrentValue(newProps.value);
+  }
+
+  updateCurrentValue = (newValue: boolean) => {
+    if (this.currentValue !== newValue) {
+      if (newValue) {
+	      this.start();
+      } else {
+	      this.stop();
+      }
     }
+    this.currentValue = newValue;
   }
 
   currentValue: boolean;

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -1,13 +1,13 @@
 // @flow
 
 import { Animated, Easing } from 'react-native';
-import AnimatableView from '../components/AnimatableView';
+import Declan from '../components';
 
 export type AnimatedValue = Animated.Value | Animated.ValueXY;
 
 export interface Animator {
   id: string,
-  target: ?AnimatableView,
+  target: ?Declan.View,
   value: AnimatedValue,
   start(): void,
   stop(): void,
@@ -15,7 +15,7 @@ export interface Animator {
 }
 
 export type BaseAnimatorProps = {
-  getTargetRef: () => AnimatableView,
+  getTargetRef: () => Declan.View,
   initialValue?: number | { x: number, y: number },
   onFinish?: () => void,
   onFinishBack?: () => void,


### PR DESCRIPTION
- Remove `react`/`react-native` from non-peer dependencies. 
- Update `import/export` shorthand.
- Allow `WhileTrue` trigger to fire on mount if the `value` is already true.